### PR TITLE
fix: update parameter name for `rich.syntax.Syntax`

### DIFF
--- a/pyinspect/panels.py
+++ b/pyinspect/panels.py
@@ -159,7 +159,7 @@ class Report(BasePanel):
         if theme is None:
             theme = self._syntax_theme
         self.tb.add_row(
-            Syntax(obj, lexer_name=language, theme=theme, **kwargs)
+            Syntax(obj, lexer=language, theme=theme, **kwargs)
         )
 
     def _add_code_file(self, obj, language="python", theme=None, **kwargs):

--- a/pyinspect/show.py
+++ b/pyinspect/show.py
@@ -284,7 +284,7 @@ def showme(func):
                 # class definition
                 Syntax(
                     getsource(class_obj),
-                    lexer_name="python",
+                    lexer="python",
                     line_range=(0, doc_end),
                     line_numbers=True,
                     theme=DimMonokai,
@@ -301,7 +301,7 @@ def showme(func):
         *output,
         Syntax(
             getsource(func),
-            lexer_name="python",
+            lexer="python",
             line_numbers=True,
             theme=Monokai,
         ),

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 requirements = [
-    "rich>=9.2.0",
+    "rich>=11.0.0",
     "numpy",
     "google",
     "bs4",


### PR DESCRIPTION
Ref: https://github.com/Textualize/rich/releases/tag/v11.0.0

> * breaking `Syntax.__init__` parameter `lexer_name` renamed to `lexer`